### PR TITLE
Fix proxyagent when running under bun

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -1,0 +1,20 @@
+name: Bun CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Bun
+      uses: antongolub/action-setup-bun@v1
+    - name: npm install, build, and test
+      run: |
+        npm install
+        npm run build --if-present
+        bun run test
+      env:
+        CI: true

--- a/components/http/proxyagent.js
+++ b/components/http/proxyagent.js
@@ -1,6 +1,19 @@
 const HTTP = require('http');
 const HTTPS = require('https');
-const TLS = require('tls');
+/** @type {typeof require("tls")} */
+const TLS = (() => {
+	// FIXME: Remove this once bun ships with `tls`.
+	try {
+		// NOTE: Instead of just using a ternary operator we do it this way to be forwards-compatible with future
+		// versions of bun that have implemented `tls`.
+		return require('tls');
+	} catch (error) {
+		if (typeof(Bun) !== 'undefined')
+			return Bun;
+		
+		throw error;
+	}
+})();
 const URL = require('url');
 
 /**


### PR DESCRIPTION
`TLS` isn't currently implemented in `bun`; but their own implementation accessible through the global `Bun` variable is close enough for it to be a drop-in-replacement in those envs. This does however ensure that once `bun` gets `tls` it'll default to that instead of the custom `bun` one.